### PR TITLE
Added error printing option. Fixed a #7.

### DIFF
--- a/PHPwrapper/GetResponseAPI.class.php
+++ b/PHPwrapper/GetResponseAPI.class.php
@@ -38,17 +38,26 @@ class GetResponse
 	private $textOperators = array('EQUALS', 'NOT_EQUALS', 'CONTAINS', 'NOT_CONTAINS', 'MATCHES');
 	
 	/**
-	 * Check cURL extension is loaded and that an API key has been passed
+	* True to enable printing, false otherwise. Set using the constructor
+	* @var boolean
+	* @access private
+	*/
+	private $errorsOn = true;
+
+	/**
+	 * Check cURL extension is loaded and that an API key has been passed, also enables or disables error printing
 	 * @param string $apiKey GetResponse API key
+	 * @param boolean $print_errors
 	 * @return void
 	 */
-	public function __construct($apiKey = null)
+	public function __construct($apiKey = null, $print_errors = true)
 	{
 		if(!extension_loaded('curl')) trigger_error('GetResponsePHP requires PHP cURL', E_USER_ERROR);
 		if(is_null($apiKey)) trigger_error('API key must be supplied', E_USER_ERROR);
 		$this->apiKey = $apiKey;
+		$this->errorsOn = ($print_errors) ? true : false;
 	}
-	
+
 	/**
 	 * Test connection to the API, returns "pong" on success
 	 * @return string
@@ -464,7 +473,13 @@ class GetResponse
 	public function addContact($campaign, $name, $email, $action = 'standard', $cycle_day = 0, $customs = array())
 	{
 		$params = array('campaign' => $campaign, 'action' => $action, 'name' => $name,
-						'email' => $email, 'cycle_day' => $cycle_day, 'ip' => $_SERVER['REMOTE_ADDR']);
+						'email' => $email, 'cycle_day' => $cycle_day);
+		if($this->isValidIp($_SERVER['REMOTE_ADDR'])){
+			echo '<h2>';
+			echo $_SERVER['REMOTE_ADDR'];
+			echo '</h2>';
+			array_push($params, $_SERVER['REMOTE_ADDR']);
+		}
 		if(!empty($customs)) {
 			foreach($customs as $key => $val) $c[] = array('name' => $key, 'content' => $val);
 			$params['customs'] = $c;
@@ -521,6 +536,25 @@ class GetResponse
 		$response = $this->execute($request);
 		return $response;
 	}
+
+	/**
+	* Returns true if the supplied ip is valid, false otherwise.
+	* @param string $ip
+	* @access private
+	*/
+	private function isValidIp($ip){
+
+		if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)){
+			if(substr_count($ip, '.') == 4){
+				return true;
+			}
+		}else if(filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)){
+				if(substr_count($ip, ':') == 7){
+					return true;
+				}
+		}
+		return false;
+	}
 	
 	/**
 	 * Return a key => value array for text comparison
@@ -570,6 +604,10 @@ class GetResponse
 		if(!(($httpCode == '200') || ($httpCode == '204'))) trigger_error('API call failed. Server returned status code '.$httpCode, E_USER_ERROR);
 		curl_close($handle);
 		if(!$response->error) return $response->result;
+		else if($this->errorsOn){
+			var_dump($request);
+			return $response->error;
+		}
 	}
 }
 


### PR DESCRIPTION
Error printing option enabled by default. Can be disabled by instantiating the class with a false second parameter.
I also fixed a bug that i reported, that caused a user whose IP can't be set correctly to be unable to be added as a contact. Concisely, i added a function called isValidIp($ip) that checks if the given parameter is either a valid IPv4 or IPv6 address and that it has the required number of colons or periods. If the ip is valid, it is pushed into the (request's) $parameters array, otherwise, it is completely ignored. 